### PR TITLE
fix(registration): white agreement box and working signature canvas

### DIFF
--- a/src/components/forms/registration/agreement-step.tsx
+++ b/src/components/forms/registration/agreement-step.tsx
@@ -224,20 +224,20 @@ export function AgreementStep({
             <div
               ref={scrollContainerRef}
               onScroll={handleScroll}
-              className="bg-white dark:bg-gray-950 border border-[var(--mmk-border)] rounded-xl p-6 max-h-[400px] overflow-y-auto prose prose-sm dark:prose-invert max-w-none
-                prose-headings:text-primary dark:prose-headings:text-white
+              className="bg-white border border-[var(--mmk-border)] rounded-xl p-6 max-h-[400px] overflow-y-auto prose prose-sm max-w-none
+                prose-headings:text-gray-900
                 prose-h1:text-xl prose-h1:font-bold prose-h1:mb-4
                 prose-h2:text-base prose-h2:font-semibold prose-h2:mt-6 prose-h2:mb-2
-                prose-p:text-sm prose-p:leading-relaxed
-                prose-li:text-sm prose-li:leading-relaxed
-                prose-strong:text-primary dark:prose-strong:text-white
+                prose-p:text-sm prose-p:leading-relaxed prose-p:text-gray-700
+                prose-li:text-sm prose-li:leading-relaxed prose-li:text-gray-700
+                prose-strong:text-gray-900
               "
               dangerouslySetInnerHTML={{ __html: agreementHtml }}
             />
 
             {/* Scroll indicator overlay */}
             {!hasScrolledToBottom && (
-              <div className="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-white dark:from-gray-950 to-transparent rounded-b-xl pointer-events-none flex items-end justify-center pb-2">
+              <div className="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-white to-transparent rounded-b-xl pointer-events-none flex items-end justify-center pb-2">
                 <p className="text-[10px] text-muted-foreground animate-bounce pointer-events-auto">
                   ↓ Scroll down to read the full agreement
                 </p>

--- a/src/components/forms/signature-pad.tsx
+++ b/src/components/forms/signature-pad.tsx
@@ -46,9 +46,14 @@ export function SignaturePad({
       if (!ctx) return;
 
       ctx.scale(dpr, dpr);
+
+      // Fill canvas with white background
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, rect.width, rect.height);
+
       ctx.lineCap = "round";
       ctx.lineJoin = "round";
-      ctx.strokeStyle = "#057baa";
+      ctx.strokeStyle = "#000000";
       ctx.lineWidth = 2.5;
       contextRef.current = ctx;
     });
@@ -151,6 +156,12 @@ export function SignaturePad({
 
     const dpr = window.devicePixelRatio || 1;
     ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
+
+    // Restore white background after clearing
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, canvas.width / dpr, canvas.height / dpr);
+    ctx.strokeStyle = "#000000";
+
     setHasDrawn(false);
     onSignatureChange(null);
   }, [onSignatureChange]);
@@ -215,14 +226,14 @@ export function SignaturePad({
 
             {/* Signature preview */}
             {typedName.trim() && (
-              <div className="bg-white dark:bg-gray-900 border-2 border-dashed border-[var(--mmk-border)] rounded-xl p-6 text-center">
+              <div className="bg-white border-2 border-dashed border-[var(--mmk-border)] rounded-xl p-6 text-center">
                 <p
-                  className="text-2xl italic text-primary dark:text-white"
+                  className="text-2xl italic text-gray-900"
                   style={{ fontFamily: "'Playfair Display', serif" }}
                 >
                   {typedName}
                 </p>
-                <div className="w-48 h-px bg-primary/30 dark:bg-white/30 mx-auto mt-3" />
+                <div className="w-48 h-px bg-gray-400 mx-auto mt-3" />
                 <p className="text-[10px] text-muted-foreground mt-1">
                   Electronic Signature
                 </p>


### PR DESCRIPTION
## Summary
- **Agreement content box**: Force white background with black text for readability — removes dark-mode variants that made text hard to read
- **Signature canvas**: Fill canvas with white background so drawn strokes export correctly, switch from blue to black ink, restore white background on clear
- **Typed signature preview**: Use `text-gray-900` for consistent readability

## Test plan
- [ ] Navigate to registration agreement step — verify agreement text is black on white
- [ ] Switch to "Draw Signature" tab — verify canvas has white background
- [ ] Draw a signature — verify strokes appear in black
- [ ] Clear the canvas — verify it resets to white
- [ ] Type a name — verify preview shows in dark text

🤖 Generated with [Claude Code](https://claude.com/claude-code)