### PR TITLE
feat(dashboard): add payment CTA for unpaid applications

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -139,19 +139,22 @@ export default function DashboardPage() {
   const isActive = data.subscription?.status === "ACTIVE";
   const needsPayment =
     data.subscription?.status === "DRAFT" &&
-    !data.payments.some((p) => p.status === "PAID" || p.status === "SUCCEEDED");
+    !data.payments.some((p) => p.status === "SUCCEEDED");
 
   const handleCheckout = async () => {
+    if (checkoutLoading) return;
     setCheckoutLoading(true);
     try {
       const res = await fetch("/api/stripe/checkout", { method: "POST" });
+      if (!res.ok) throw new Error("Checkout failed");
       const result = await res.json();
       if (result.url) {
         window.location.href = result.url;
+      } else {
+        throw new Error("No checkout URL returned");
       }
     } catch {
-      // silently fail
-    } finally {
+      setError("Unable to start payment. Please try again or visit the Subscription page.");
       setCheckoutLoading(false);
     }
   };
@@ -171,7 +174,7 @@ export default function DashboardPage() {
     {
       icon: Banknote,
       label: "Payment",
-      done: data.payments.some((p) => p.status === "PAID"),
+      done: data.payments.some((p) => p.status === "SUCCEEDED"),
     },
     {
       icon: CheckCircle2,
@@ -268,6 +271,7 @@ export default function DashboardPage() {
             <Button
               onClick={handleCheckout}
               disabled={checkoutLoading}
+              aria-busy={checkoutLoading}
               className="rounded-full bg-gradient-to-r from-[#0ea5e9] to-[#38bdf8] text-white font-semibold px-6 gap-2 hover:shadow-lg hover:-translate-y-0.5 transition-all duration-300 shrink-0"
             >
               {checkoutLoading ? (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -26,6 +26,7 @@ import {
   FileCheck,
   Banknote,
   ClipboardCheck,
+  Loader2,
 } from "lucide-react";
 
 interface DashboardData {
@@ -83,6 +84,7 @@ export default function DashboardPage() {
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [checkoutLoading, setCheckoutLoading] = useState(false);
 
   const fetchDashboard = useCallback(() => {
     fetch("/api/dashboard")
@@ -135,6 +137,24 @@ export default function DashboardPage() {
   const subStatus = statusConfig[data.subscription?.status || "DRAFT"] || statusConfig.DRAFT;
   const latestAgreement = data.agreements[0];
   const isActive = data.subscription?.status === "ACTIVE";
+  const needsPayment =
+    data.subscription?.status === "DRAFT" &&
+    !data.payments.some((p) => p.status === "PAID" || p.status === "SUCCEEDED");
+
+  const handleCheckout = async () => {
+    setCheckoutLoading(true);
+    try {
+      const res = await fetch("/api/stripe/checkout", { method: "POST" });
+      const result = await res.json();
+      if (result.url) {
+        window.location.href = result.url;
+      }
+    } catch {
+      // silently fail
+    } finally {
+      setCheckoutLoading(false);
+    }
+  };
 
   // Journey steps for service tracker
   const journeySteps = [
@@ -229,6 +249,42 @@ export default function DashboardPage() {
           color="#38bdf8"
         />
       </div>
+
+      {/* ───── Payment CTA (DRAFT status, no payment yet) ───── */}
+      {needsPayment && (
+        <Card className="border-[#0ea5e9]/30 bg-[#0ea5e9]/5 rounded-2xl overflow-hidden">
+          <CardContent className="p-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="flex items-start gap-3">
+              <div className="w-10 h-10 rounded-xl bg-[#0ea5e9]/10 flex items-center justify-center shrink-0">
+                <CreditCard className="size-5 text-[#0ea5e9]" />
+              </div>
+              <div>
+                <p className="text-sm font-semibold">Complete Your Payment</p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Your application is ready. Pay the £75 annual fee to submit it for review.
+                </p>
+              </div>
+            </div>
+            <Button
+              onClick={handleCheckout}
+              disabled={checkoutLoading}
+              className="rounded-full bg-gradient-to-r from-[#0ea5e9] to-[#38bdf8] text-white font-semibold px-6 gap-2 hover:shadow-lg hover:-translate-y-0.5 transition-all duration-300 shrink-0"
+            >
+              {checkoutLoading ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  Redirecting…
+                </>
+              ) : (
+                <>
+                  <CreditCard className="size-4" />
+                  Pay Now — £75
+                </>
+              )}
+            </Button>
+          </CardContent>
+        </Card>
+      )}
 
       {/* ───── Status Cards Grid ───── */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">


### PR DESCRIPTION
## Summary
- Adds a prominent "Pay Now — £75" banner on the client dashboard when the subscription is in `DRAFT` status and no payment has been made
- Uses the same `POST /api/stripe/checkout` flow as the existing subscription page
- Banner auto-hides once payment is completed (status moves to `PENDING_APPROVAL`)

Closes #25

## Changes
- **`src/app/dashboard/page.tsx`**: Added `needsPayment` flag, `handleCheckout` handler, and payment CTA card between welcome banner and status cards grid

## How it works
1. `needsPayment` checks: `subscription.status === "DRAFT"` AND no payment with `PAID`/`SUCCEEDED` status
2. When clicked, calls the existing Stripe checkout API endpoint
3. Shows loading spinner while redirecting to Stripe hosted checkout
4. After payment, the webhook updates status to `PENDING_APPROVAL` and the banner disappears on next load

## Test plan
- [ ] Log in as a client with `DRAFT` subscription status — verify "Pay Now" banner appears
- [ ] Click "Pay Now" — verify redirect to Stripe checkout
- [ ] Log in as a client with `ACTIVE` subscription — verify banner does NOT appear
- [ ] Log in as a client with `PENDING_APPROVAL` status — verify banner does NOT appear
- [ ] Test on mobile viewport — verify banner stacks vertically
- [ ] Complete a test payment — verify banner disappears after page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)